### PR TITLE
Add support for start/stop/pause stream events

### DIFF
--- a/aioresonate/server/__init__.py
+++ b/aioresonate/server/__init__.py
@@ -14,9 +14,19 @@ __all__ = [
     "PlayerRemovedEvent",
     "ResonateEvent",
     "ResonateServer",
+    "StreamPauseEvent",
+    "StreamStartEvent",
+    "StreamStopEvent",
     "VolumeChangedEvent",
 ]
 
 from .group import AudioFormat, PlayerGroup
-from .player import Player, PlayerEvent, VolumeChangedEvent
+from .player import (
+    Player,
+    PlayerEvent,
+    StreamPauseEvent,
+    StreamStartEvent,
+    StreamStopEvent,
+    VolumeChangedEvent,
+)
 from .server import PlayerAddedEvent, PlayerRemovedEvent, ResonateEvent, ResonateServer

--- a/aioresonate/server/player.py
+++ b/aioresonate/server/player.py
@@ -12,6 +12,7 @@ from attr import dataclass
 
 from aioresonate import models
 from aioresonate.models import client_messages, server_messages
+from aioresonate.models.types import MediaCommand
 
 from .group import PlayerGroup
 
@@ -35,6 +36,21 @@ class VolumeChangedEvent(PlayerEvent):
 
     volume: int
     muted: bool
+
+
+@dataclass
+class StreamStartEvent(PlayerEvent):
+    """The player issued a start/play stream command event."""
+
+
+@dataclass
+class StreamStopEvent(PlayerEvent):
+    """The player issued a stop stream command event."""
+
+
+@dataclass
+class StreamPauseEvent(PlayerEvent):
+    """The player issued a pause stream command event."""
 
 
 class Player:
@@ -340,8 +356,16 @@ class Player:
                         )
                     )
                 )
-            case client_messages.StreamCommandMessage():
-                raise NotImplementedError
+            case client_messages.StreamCommandMessage(stream_command):
+                match stream_command.command:
+                    case MediaCommand.PLAY:
+                        self._signal_event(StreamStartEvent())
+                    case MediaCommand.STOP:
+                        self._signal_event(StreamStopEvent())
+                    case MediaCommand.PAUSE:
+                        self._signal_event(StreamPauseEvent())
+                    case _:
+                        raise NotImplementedError
             case client_messages.ClientMessage():
                 pass  # unused base type
 

--- a/aioresonate/server/player.py
+++ b/aioresonate/server/player.py
@@ -364,8 +364,9 @@ class Player:
                         self._signal_event(StreamStopEvent())
                     case MediaCommand.PAUSE:
                         self._signal_event(StreamPauseEvent())
-                    case _:
-                        raise NotImplementedError
+                        raise NotImplementedError(
+                            f"MediaCommand {stream_command.command} is not supported"
+                        )
             case client_messages.ClientMessage():
                 pass  # unused base type
 


### PR DESCRIPTION
Start, pause, and stop stream events issued by a player are now passed to the event callback registered by `add_event_listener`.