### PR TITLE
Add group events

### DIFF
--- a/aioresonate/server/__init__.py
+++ b/aioresonate/server/__init__.py
@@ -8,6 +8,7 @@ ResonateServer is the core of the music listening experience, responsible for:
 
 __all__ = [
     "AudioFormat",
+    "GroupDeletedEvent",
     "GroupEvent",
     "GroupMemberAddedEvent",
     "GroupMemberRemovedEvent",
@@ -29,6 +30,7 @@ __all__ = [
 
 from .group import (
     AudioFormat,
+    GroupDeletedEvent,
     GroupEvent,
     GroupMemberAddedEvent,
     GroupMemberRemovedEvent,

--- a/aioresonate/server/__init__.py
+++ b/aioresonate/server/__init__.py
@@ -8,6 +8,7 @@ ResonateServer is the core of the music listening experience, responsible for:
 
 __all__ = [
     "AudioFormat",
+    "GroupEvent",
     "Player",
     "PlayerAddedEvent",
     "PlayerEvent",
@@ -21,7 +22,7 @@ __all__ = [
     "VolumeChangedEvent",
 ]
 
-from .group import AudioFormat, PlayerGroup
+from .group import AudioFormat, GroupEvent, PlayerGroup
 from .player import (
     Player,
     PlayerEvent,

--- a/aioresonate/server/__init__.py
+++ b/aioresonate/server/__init__.py
@@ -9,12 +9,15 @@ ResonateServer is the core of the music listening experience, responsible for:
 __all__ = [
     "AudioFormat",
     "GroupEvent",
+    "GroupMemberAddedEvent",
+    "GroupMemberRemovedEvent",
     "GroupState",
     "GroupStateChangedEvent",
     "Player",
     "PlayerAddedEvent",
     "PlayerEvent",
     "PlayerGroup",
+    "PlayerGroupChangedEvent",
     "PlayerRemovedEvent",
     "ResonateEvent",
     "ResonateServer",
@@ -24,10 +27,19 @@ __all__ = [
     "VolumeChangedEvent",
 ]
 
-from .group import AudioFormat, GroupEvent, GroupState, GroupStateChangedEvent, PlayerGroup
+from .group import (
+    AudioFormat,
+    GroupEvent,
+    GroupMemberAddedEvent,
+    GroupMemberRemovedEvent,
+    GroupState,
+    GroupStateChangedEvent,
+    PlayerGroup,
+)
 from .player import (
     Player,
     PlayerEvent,
+    PlayerGroupChangedEvent,
     StreamPauseEvent,
     StreamStartEvent,
     StreamStopEvent,

--- a/aioresonate/server/__init__.py
+++ b/aioresonate/server/__init__.py
@@ -9,6 +9,8 @@ ResonateServer is the core of the music listening experience, responsible for:
 __all__ = [
     "AudioFormat",
     "GroupEvent",
+    "GroupState",
+    "GroupStateChangedEvent",
     "Player",
     "PlayerAddedEvent",
     "PlayerEvent",
@@ -22,7 +24,7 @@ __all__ = [
     "VolumeChangedEvent",
 ]
 
-from .group import AudioFormat, GroupEvent, PlayerGroup
+from .group import AudioFormat, GroupEvent, GroupState, GroupStateChangedEvent, PlayerGroup
 from .player import (
     Player,
     PlayerEvent,

--- a/aioresonate/server/group.py
+++ b/aioresonate/server/group.py
@@ -205,6 +205,9 @@ class PlayerGroup:
             )
         )
 
+        self._current_state = GroupState.PLAYING
+        self._signal_event(GroupStateChangedEvent(GroupState.PLAYING))
+
     def determine_player_format(
         self,
         player: "Player",
@@ -475,6 +478,10 @@ class PlayerGroup:
         self._audio_encoders.clear()
         self._audio_headers.clear()
         self._stream_task = None
+
+        if self._current_state != GroupState.IDLE:
+            self._signal_event(GroupStateChangedEvent(GroupState.IDLE))
+            self._current_state = GroupState.IDLE
         return True
 
     def set_metadata(self, metadata: Metadata) -> None:
@@ -786,8 +793,6 @@ class PlayerGroup:
         # - Support other formats than pcm
         # - Optimize this
 
-        self._signal_event(GroupStateChangedEvent(GroupState.PLAYING))
-
         try:
             logger.debug(
                 "_stream_audio started: start_time_us=%d, audio_format=%s",
@@ -870,5 +875,5 @@ class PlayerGroup:
             logger.debug("Audio streaming loop ended")
         except Exception:
             logger.exception("failed to stream audio")
-
-        self._signal_event(GroupStateChangedEvent(GroupState.IDLE))
+        finally:
+            self.stop()

--- a/aioresonate/server/group.py
+++ b/aioresonate/server/group.py
@@ -146,7 +146,7 @@ class PlayerGroup:
     """Preferred codec used by the current stream."""
     _event_cbs: list[Callable[[GroupEvent], Coroutine[None, None, None]]]
     """List of event callbacks for this group."""
-    _current_state: GroupState
+    _current_state: GroupState = GroupState.IDLE
     """Current playback state of the group."""
 
     def __init__(self, server: "ResonateServer", *args: "Player") -> None:
@@ -168,7 +168,6 @@ class PlayerGroup:
         self._audio_encoders = {}
         self._audio_headers = {}
         self._event_cbs = []
-        self._current_state = GroupState.IDLE
         logger.debug(
             "PlayerGroup initialized with %d player(s): %s",
             len(self._players),

--- a/aioresonate/server/group.py
+++ b/aioresonate/server/group.py
@@ -72,6 +72,11 @@ class GroupMemberRemovedEvent(GroupEvent):
     """The ID of the player that was removed."""
 
 
+@dataclass
+class GroupDeletedEvent(GroupEvent):
+    """This group has no more members and has been deleted."""
+
+
 @dataclass(frozen=True)
 class AudioFormat:
     """
@@ -616,7 +621,12 @@ class PlayerGroup:
                 except QueueFull:
                     logger.warning("Failed to send session end message to %s", player.player_id)
                 del self._player_formats[player.player_id]
-        self._signal_event(GroupMemberRemovedEvent(player.player_id))
+        if not self._players:
+            # Emit event for group deletion, no players left
+            self._signal_event(GroupDeletedEvent())
+        else:
+            # Emit event for player removal
+            self._signal_event(GroupMemberRemovedEvent(player.player_id))
         # Each player needs to be in a group, add it to a new one
         player._set_group(PlayerGroup(self._server, player))  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
 

--- a/aioresonate/server/player.py
+++ b/aioresonate/server/player.py
@@ -68,6 +68,14 @@ class StreamPauseEvent(PlayerEvent):
     """The player issued a pause stream command event."""
 
 
+@dataclass
+class PlayerGroupChangedEvent(PlayerEvent):
+    """The player was moved to a different group."""
+
+    new_group: "PlayerGroup"
+    """The new group the player is now part of."""
+
+
 class Player:
     """
     A Player that is connected to a ResonateServer.
@@ -276,6 +284,9 @@ class Player:
             group: The PlayerGroup to assign this player to.
         """
         self._group = group
+
+        # Emit event for group change
+        self._signal_event(PlayerGroupChangedEvent(group))
 
     def ungroup(self) -> None:
         """


### PR DESCRIPTION
This PR add events around groups, mainly:
- Event system for groups: Can be used through `PlayerGroup.add_event_listener`
- Group member changes: `GroupMemberAddedEvent`, `GroupMemberRemovedEvent`, `GroupDeletedEvent` (when no members belong to this group anymore)
- Player group changes event for Players: `PlayerGroupChangedEvent`

And fixes an issue where no `session/end` message was sent after playback stopped.