### PR TITLE
Stop playback before adding players to new groups

### DIFF
--- a/aioresonate/server/group.py
+++ b/aioresonate/server/group.py
@@ -557,6 +557,7 @@ class PlayerGroup:
             player: The player to add to this group.
         """
         logger.debug("adding %s to group with members: %s", player.player_id, self._players)
+        _ = player.group.stop()
         if player in self._players:
             return
         # Remove it from any existing group first


### PR DESCRIPTION
# Known Issues

There is no delay between the session end and start messages, this is partly intentional to test the ESPHome firmware.
Steps to reproduce with Music Assistant:
1. Start playback of different titles on players A and B
2. Group A to B